### PR TITLE
Apply type color to array gap lines

### DIFF
--- a/bit_field/render.py
+++ b/bit_field/render.py
@@ -211,11 +211,27 @@ class Renderer(object):
                 x1 = x1_raw + margin
                 x2 = x2_outer - width
                 pts = f"{x1},{top_y} {x1+width},{top_y} {x2_outer},{bottom_y} {x2},{bottom_y}"
-                color = typeColor(e.get('type')) if e.get('type') is not None else 'black'
-                grp = ['g', {'stroke': color, 'stroke-width': self.stroke_width}]
-                grp.append(['polygon', {'points': pts, 'fill': '#fff'}])
-                grp.append(['line', {'x1': x1, 'y1': top_y, 'x2': x2, 'y2': bottom_y}])
-                grp.append(['line', {'x1': x1+width, 'y1': top_y, 'x2': x2_outer, 'y2': bottom_y}])
+                line_color = typeColor(e.get('type')) if e.get('type') is not None else 'black'
+                grp = ['g', {'stroke-width': self.stroke_width}]
+                grp.append(['polygon', {
+                    'points': pts,
+                    'fill': '#fff',
+                    'stroke': '#000'
+                }])
+                grp.append(['line', {
+                    'x1': x1,
+                    'y1': top_y,
+                    'x2': x2,
+                    'y2': bottom_y,
+                    'stroke': line_color
+                }])
+                grp.append(['line', {
+                    'x1': x1+width,
+                    'y1': top_y,
+                    'x2': x2_outer,
+                    'y2': bottom_y,
+                    'stroke': line_color
+                }])
                 if 'name' in e:
                     mid_x = (x1 + x2_outer) / 2
                     mid_y = (top_y + bottom_y) / 2 + self.fontsize / 2

--- a/bit_field/test/test_array_render.py
+++ b/bit_field/test/test_array_render.py
@@ -14,6 +14,7 @@ def test_array_polygon_type():
     svg = jsonml_stringify(jsonml)
     assert '<polygon' in svg
     assert 'fill="#fff"' in svg
+    assert 'stroke="#000"' in svg
     assert f'stroke="{typeColor(4)}"' in svg
     assert 'gap' in svg
     assert renderer.lanes == 2


### PR DESCRIPTION
## Summary
- ensure array gap polygons stay white with black outline
- color array gap lines using the `type` color
- update tests to reflect new gap coloring

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68be6a39cc2c83208b78bef3be589bf2