### PR TITLE
Draw array gaps over type-colored background

### DIFF
--- a/bit_field/render.py
+++ b/bit_field/render.py
@@ -213,10 +213,11 @@ class Renderer(object):
                 pts = f"{x1},{top_y} {x1+width},{top_y} {x2_outer},{bottom_y} {x2},{bottom_y}"
                 color = typeColor(e.get('type')) if e.get('type') is not None else 'black'
                 grp = ['g', {'stroke': color, 'stroke-width': self.stroke_width}]
-                # fill the bounding box with the type color to avoid transparency
+                # fill the full gap bounds with the type color to avoid transparent edges
                 if e.get('type') is not None:
-                    left = min(x1, x2)
-                    right = max(x1 + width, x2_outer)
+                    # use raw coordinates so the background reaches the lane boundaries
+                    left = x1_raw
+                    right = self.hspace if (x2_raw == 0 and end > start) else x2_raw
                     rect = f"{left},{top_y} {right},{top_y} {right},{bottom_y} {left},{bottom_y}"
                     grp.append(['polygon', {
                         'points': rect,

--- a/bit_field/test/test_array_render.py
+++ b/bit_field/test/test_array_render.py
@@ -44,6 +44,17 @@ def test_array_polygon_type():
     assert x1 == pytest.approx(step * 8 + margin)
     assert x2 == pytest.approx(renderer.hspace - margin)
 
+    color_poly = next(p for p in polygons if p.get('fill') == typeColor(4))
+    c_coords = [tuple(map(float, p.split(','))) for p in color_poly['points'].split()]
+    c_top = c_coords[0][1]
+    c_bottom = c_coords[2][1]
+    assert c_top == pytest.approx(base_y)
+    assert c_bottom == pytest.approx(base_y + renderer.vlane)
+    c_x1 = c_coords[0][0]
+    c_x2 = c_coords[2][0]
+    assert c_x1 == pytest.approx(step * 8)
+    assert c_x2 == pytest.approx(renderer.hspace)
+
 
 def test_array_full_lane_wedge():
     reg = [


### PR DESCRIPTION
## Summary
- fill array gap bounding box with type-based color
- keep wedge gap white and overlay type-colored background
- extend array rendering tests for new colored polygons

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68be6da3c3648320a77df60ed201f9ec