### PR TITLE
Support multiline label_lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,13 @@ html = jsonml_stringify(jsonml)
 
 Add a rotated label spanning multiple lanes either by passing a
 `label_lines` configuration or by appending an object with a
-`"label_lines"` key to the descriptor list:
+`"label_lines"` key to the descriptor list. Newline characters (`\n`)
+in the label text create multiple lines:
 
 ```python
 reg = [
   {"bits": 8, "name": "data"},
-  {"label_lines": "Demo", "font_size": 6, "start_line": 0, "end_line": 3, "layout": "right"},
+  {"label_lines": "Line1\nLine2", "font_size": 6, "start_line": 0, "end_line": 3, "layout": "right"},
 ]
 render(reg, bits=8)
 ```

--- a/bit_field/render.py
+++ b/bit_field/render.py
@@ -227,16 +227,34 @@ class Renderer(object):
             x = -self.label_margin / 2
         else:
             x = self.hspace + self.label_margin / 2
-        return ['text', {
-            'x': x,
-            'y': mid_y,
+
+        lines = text.split('\n')
+        if len(lines) == 1:
+            return ['text', {
+                'x': x,
+                'y': mid_y,
+                'font-size': font_size,
+                'font-family': self.fontfamily,
+                'font-weight': self.fontweight,
+                'text-anchor': 'middle',
+                'dominant-baseline': 'middle',
+                'transform': 'rotate(90,{},{})'.format(x, mid_y)
+            }, text]
+
+        line_height = font_size * 1.2
+        start_y = mid_y - line_height * (len(lines) - 1) / 2
+        attrs = {
             'font-size': font_size,
             'font-family': self.fontfamily,
             'font-weight': self.fontweight,
             'text-anchor': 'middle',
             'dominant-baseline': 'middle',
             'transform': 'rotate(90,{},{})'.format(x, mid_y)
-        }, text]
+        }
+        elements = ['text', attrs]
+        for i, line in enumerate(lines):
+            elements.append(['tspan', {'x': x, 'y': start_y + line_height * i}, line])
+        return elements
 
     def legend_items(self):
         items = ['g', {'transform': t(0, self.stroke_width / 2)}]

--- a/bit_field/test/test_label_lines.py
+++ b/bit_field/test/test_label_lines.py
@@ -8,7 +8,7 @@ def _make_reg(bits=8, lanes=8):
 
 def _find_text(node, text):
     if isinstance(node, list):
-        if node and node[0] == "text" and text in node[2:]:
+        if node and node[0] in ("text", "tspan") and text in node[2:]:
             return node
         for child in node[1:]:
             res = _find_text(child, text)
@@ -41,6 +41,16 @@ def test_label_lines_draws_text_outside_left():
     root_attrs = root[1]
     view_min_x = float(root_attrs["viewbox"].split()[0])
     assert view_min_x < 0
+
+
+def test_label_lines_multiline():
+    reg = _make_reg()
+    cfg = {"label_lines": "Line1\nLine2", "font_size": 6, "start_line": 0, "end_line": 3, "layout": "right"}
+    res = render(reg, bits=8, label_lines=cfg)
+    node1 = _find_text(res, "Line1")
+    node2 = _find_text(res, "Line2")
+    assert node1 is not None
+    assert node2 is not None
 
 
 def test_label_lines_invalid_range():


### PR DESCRIPTION
## Summary
- allow `label_lines` text to include `\n` for multi-line labels
- test multi-line label rendering
- document newline support in `label_lines`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68be7a1851f48320b91938f2e1a4c9d1