### PR TITLE
feat: add bracketed label lines

### DIFF
--- a/bit_field/render.py
+++ b/bit_field/render.py
@@ -156,9 +156,13 @@ class Renderer(object):
 
         left_margin = right_margin = 0
         self.label_margin = 0
+        self.label_gap = 0
+        self.label_width = 0
         if self.label_lines is not None:
-            font_size = self.label_lines.get('font_size', self.fontsize)
-            self.label_margin = font_size * 2
+            cage_width = self.hspace / self.mod
+            self.label_gap = cage_width / 2
+            self.label_width = cage_width
+            self.label_margin = self.label_gap + self.label_width
             if self.label_lines['layout'] == 'left':
                 left_margin = self.label_margin
             else:
@@ -223,38 +227,55 @@ class Renderer(object):
         top_y = base_y + self.vlane * start
         bottom_y = base_y + self.vlane * (end + 1)
         mid_y = (top_y + bottom_y) / 2
+        gap = self.label_gap
+        width = self.label_width
         if layout == 'left':
-            x = -self.label_margin / 2
+            x = -(gap + width / 2)
+            vline_x = -gap
+            hstart = 0
+            hend = -gap
         else:
-            x = self.hspace + self.label_margin / 2
+            x = self.hspace + gap + width / 2
+            vline_x = self.hspace + gap
+            hstart = self.hspace
+            hend = self.hspace + gap
 
         lines = text.split('\n')
-        if len(lines) == 1:
-            return ['text', {
-                'x': x,
-                'y': mid_y,
-                'font-size': font_size,
-                'font-family': self.fontfamily,
-                'font-weight': self.fontweight,
-                'text-anchor': 'middle',
-                'dominant-baseline': 'middle',
-                'transform': 'rotate(90,{},{})'.format(x, mid_y)
-            }, text]
-
-        line_height = font_size * 1.2
-        start_y = mid_y - line_height * (len(lines) - 1) / 2
-        attrs = {
+        text_attrs = {
+            'x': x,
+            'y': mid_y,
             'font-size': font_size,
             'font-family': self.fontfamily,
             'font-weight': self.fontweight,
             'text-anchor': 'middle',
             'dominant-baseline': 'middle',
-            'transform': 'rotate(90,{},{})'.format(x, mid_y)
+            'transform': 'rotate(90,{},{})'.format(x, mid_y),
+            'textLength': width,
+            'lengthAdjust': 'spacingAndGlyphs'
         }
-        elements = ['text', attrs]
-        for i, line in enumerate(lines):
-            elements.append(['tspan', {'x': x, 'y': start_y + line_height * i}, line])
-        return elements
+        if len(lines) == 1:
+            text_element = ['text', text_attrs, text]
+        else:
+            line_height = font_size * 1.2
+            start_y = mid_y - line_height * (len(lines) - 1) / 2
+            attrs = text_attrs.copy()
+            del attrs['x']
+            del attrs['y']
+            elements = ['text', attrs]
+            for i, line in enumerate(lines):
+                elements.append(['tspan', {'x': x, 'y': start_y + line_height * i}, line])
+            text_element = elements
+
+        bracket = ['g', {
+            'stroke': 'black',
+            'stroke-width': self.stroke_width,
+            'fill': 'none'
+        },
+            ['line', {'x1': hstart, 'y1': top_y, 'x2': hend, 'y2': top_y}],
+            ['line', {'x1': hstart, 'y1': bottom_y, 'x2': hend, 'y2': bottom_y}],
+            ['line', {'x1': vline_x, 'y1': top_y, 'x2': vline_x, 'y2': bottom_y}]
+        ]
+        return ['g', {}, bracket, text_element]
 
     def legend_items(self):
         items = ['g', {'transform': t(0, self.stroke_width / 2)}]

--- a/bit_field/test/test_label_lines.py
+++ b/bit_field/test/test_label_lines.py
@@ -17,6 +17,25 @@ def _find_text(node, text):
     return None
 
 
+def _find_line(node, x1, x2, y1, y2, tol=1e-6):
+    if isinstance(node, list):
+        if node and node[0] == "line":
+            attrs = node[1]
+            if all(k in attrs for k in ("x1", "x2", "y1", "y2")):
+                if (
+                    abs(float(attrs["x1"]) - x1) < tol
+                    and abs(float(attrs["x2"]) - x2) < tol
+                    and abs(float(attrs["y1"]) - y1) < tol
+                    and abs(float(attrs["y2"]) - y2) < tol
+                ):
+                    return node
+        for child in node[1:]:
+            res = _find_line(child, x1, x2, y1, y2, tol)
+            if res:
+                return res
+    return None
+
+
 def test_label_lines_draws_text_outside_right():
     reg = _make_reg()
     cfg = {"label_lines": "Demo", "font_size": 6, "start_line": 0, "end_line": 3, "layout": "right"}
@@ -26,7 +45,14 @@ def test_label_lines_draws_text_outside_right():
     attrs = node[1]
     assert attrs["font-size"] == 6
     assert "rotate(90" in attrs.get("transform", "")
-    assert attrs["x"] > 640
+    assert attrs["x"] == pytest.approx(720)
+    assert attrs["textLength"] == pytest.approx(80)
+    top_y = 14 * 1.2
+    vlane = 80 - 14 * 1.2
+    bottom_y = top_y + vlane * 4
+    assert _find_line(res, 640, 680, top_y, top_y) is not None
+    assert _find_line(res, 640, 680, bottom_y, bottom_y) is not None
+    assert _find_line(res, 680, 680, top_y, bottom_y) is not None
 
 
 def test_label_lines_draws_text_outside_left():
@@ -36,11 +62,17 @@ def test_label_lines_draws_text_outside_left():
     node = _find_text(res, "Demo")
     assert node is not None
     attrs = node[1]
-    assert attrs["x"] < 0
+    assert attrs["x"] == pytest.approx(-80)
     root = res
     root_attrs = root[1]
     view_min_x = float(root_attrs["viewbox"].split()[0])
-    assert view_min_x < 0
+    assert view_min_x == pytest.approx(-120)
+    top_y = 14 * 1.2
+    vlane = 80 - 14 * 1.2
+    bottom_y = top_y + vlane * 4
+    assert _find_line(res, 0, -40, top_y, top_y) is not None
+    assert _find_line(res, 0, -40, bottom_y, bottom_y) is not None
+    assert _find_line(res, -40, -40, top_y, bottom_y) is not None
 
 
 def test_label_lines_multiline():


### PR DESCRIPTION
## Summary
- position label line text one cage-width from bitfield
- draw bracket lines around label line annotations
- test label lines rendering and bracket geometry

## Testing
- `pytest bit_field/test/test_label_lines.py::test_label_lines_draws_text_outside_right -q`
- `pytest bit_field/test/test_label_lines.py::test_label_lines_draws_text_outside_left -q`
- `pytest -q` *(fails: Command '['git', 'describe', '--tags', '--match', 'v*']' returned non-zero exit status 128)*

------
https://chatgpt.com/codex/tasks/task_e_68be7c946f9083209e9dc1203d9c9acf