### PR TITLE
Allow label_lines to span two lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ render(reg, bits=8)
 ```
 
 The label is drawn outside the bitfield on the requested side.  It is
-rendered only if `end_line - start_line >= 3`.
+rendered only if `end_line - start_line >= 2`.
 
 ## CLI Usage
 

--- a/bit_field/render.py
+++ b/bit_field/render.py
@@ -208,8 +208,8 @@ class Renderer(object):
             raise ValueError('label_lines start_line and end_line must be non-negative')
         if end >= self.lanes or start >= self.lanes:
             raise ValueError('label_lines start_line/end_line exceed number of lanes')
-        if end - start < 3:
-            raise ValueError('label_lines must cover at least 3 lines')
+        if end - start < 2:
+            raise ValueError('label_lines must cover at least 2 lines')
         layout = self.label_lines['layout']
         if layout not in ('left', 'right'):
             raise ValueError('label_lines layout must be "left" or "right"')

--- a/bit_field/render.py
+++ b/bit_field/render.py
@@ -99,8 +99,7 @@ class Renderer(object):
                 lsb += e['bits']
         return lsb
 
-    def render(self, desc):
-        # allow label_lines configuration within descriptor list
+    def _extract_label_lines(self, desc):
         if self.label_lines is None:
             filtered = []
             for e in desc:
@@ -108,9 +107,20 @@ class Renderer(object):
                     self.label_lines = e
                 else:
                     filtered.append(e)
-            desc = filtered
-        else:
-            desc = [e for e in desc if not (isinstance(e, dict) and 'label_lines' in e)]
+            return filtered
+        return [e for e in desc if not (isinstance(e, dict) and 'label_lines' in e)]
+
+    def _label_lines_margins(self):
+        cage_width = self.hspace / self.mod
+        self.label_gap = cage_width / 2
+        self.label_width = cage_width
+        self.label_margin = self.label_gap + self.label_width
+        if self.label_lines['layout'] == 'left':
+            return self.label_margin, 0
+        return 0, self.label_margin
+
+    def render(self, desc):
+        desc = self._extract_label_lines(desc)
 
         self.total_bits = self.get_total_bits(desc)
         if self.lanes is None:
@@ -159,14 +169,7 @@ class Renderer(object):
         self.label_gap = 0
         self.label_width = 0
         if self.label_lines is not None:
-            cage_width = self.hspace / self.mod
-            self.label_gap = cage_width / 2
-            self.label_width = cage_width
-            self.label_margin = self.label_gap + self.label_width
-            if self.label_lines['layout'] == 'left':
-                left_margin = self.label_margin
-            else:
-                right_margin = self.label_margin
+            left_margin, right_margin = self._label_lines_margins()
 
         canvas_width = self.hspace + left_margin + right_margin
         view_min_x = -left_margin

--- a/bit_field/test/test_label_lines.py
+++ b/bit_field/test/test_label_lines.py
@@ -96,14 +96,14 @@ def test_label_lines_invalid_range():
 
 def test_label_lines_too_short():
     reg = _make_reg()
-    cfg = {"label_lines": "X", "font_size": 6, "start_line": 0, "end_line": 2, "layout": "left"}
+    cfg = {"label_lines": "X", "font_size": 6, "start_line": 0, "end_line": 1, "layout": "left"}
     with pytest.raises(ValueError):
         render(reg, bits=8, label_lines=cfg)
 
 
 def test_label_lines_from_desc():
     reg = _make_reg()
-    reg.append({"label_lines": "Demo", "font_size": 6, "start_line": 0, "end_line": 3, "layout": "left"})
+    reg.append({"label_lines": "Demo", "font_size": 6, "start_line": 0, "end_line": 2, "layout": "left"})
     res = render(reg, bits=8)
     node = _find_text(res, "Demo")
     assert node is not None
@@ -111,6 +111,6 @@ def test_label_lines_from_desc():
 
 def test_label_lines_from_desc_invalid():
     reg = _make_reg()
-    reg.append({"label_lines": "X", "font_size": 6, "start_line": 0, "end_line": 2, "layout": "right"})
+    reg.append({"label_lines": "X", "font_size": 6, "start_line": 0, "end_line": 1, "layout": "right"})
     with pytest.raises(ValueError):
         render(reg, bits=8)


### PR DESCRIPTION
## Summary
- allow `label_lines` configurations that cover two lanes
- document new minimum requirement in README
- update tests for two-line labels

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68be81cf2bac83208601d9c108804ca2