### PR TITLE
Enable left-side label lines with layout parameter

### DIFF
--- a/bit_field/render.py
+++ b/bit_field/render.py
@@ -178,7 +178,7 @@ class Renderer(object):
             'xmlns': 'http://www.w3.org/2000/svg',
             'width': canvas_width,
             'height': height,
-            'viewbox': ' '.join(str(x) for x in [view_min_x, 0, canvas_width, height])
+            'viewBox': ' '.join(str(x) for x in [view_min_x, 0, canvas_width, height])
         }]
 
         if self.legend:
@@ -236,10 +236,12 @@ class Renderer(object):
             x = -(gap + width / 2)
             left = x - width / 2
             right = x + width / 2
+            angle = -90
         else:
             x = self.hspace + gap + width / 2
             left = x - width / 2
             right = x + width / 2
+            angle = 90
 
         lines = text.split('\n')
         text_attrs = {
@@ -250,7 +252,7 @@ class Renderer(object):
             'font-weight': self.fontweight,
             'text-anchor': 'middle',
             'dominant-baseline': 'middle',
-            'transform': 'rotate(90,{},{})'.format(x, mid_y),
+            'transform': 'rotate({},{},{})'.format(angle, x, mid_y),
             'textLength': width,
             'lengthAdjust': 'spacingAndGlyphs'
         }

--- a/bit_field/test/alpha.svg
+++ b/bit_field/test/alpha.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<svg height="165" viewbox="0 0 649 165" width="649" xmlns="http://www.w3.org/2000/svg">
+<svg height="165" viewBox="0 0 649 165" width="649" xmlns="http://www.w3.org/2000/svg">
 	<g transform="translate(4.5, 80.5)">
 		<g stroke="black" stroke-linecap="round" stroke-width="1" transform="translate(0, 20.0)">
 			<line x2="640"/>

--- a/bit_field/test/test_label_lines.py
+++ b/bit_field/test/test_label_lines.py
@@ -64,9 +64,10 @@ def test_label_lines_draws_text_outside_left():
     assert node is not None
     attrs = node[1]
     assert attrs["x"] == pytest.approx(-80)
+    assert "rotate(-90" in attrs.get("transform", "")
     root = res
     root_attrs = root[1]
-    view_min_x = float(root_attrs["viewbox"].split()[0])
+    view_min_x = float(root_attrs["viewBox"].split()[0])
     assert view_min_x == pytest.approx(-120)
     top_y = 14 * 1.2
     vlane = 80 - 14 * 1.2


### PR DESCRIPTION
## Summary
- Allow label line text to rotate properly when placed on the left side
- Add a test ensuring left layout applies negative rotation
- Use proper `viewBox` so the canvas expands to the left for left-side labels

## Testing
- `pytest bit_field/test/test_label_lines.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68be854a91408320a0b9bd82c8457273