### PR TITLE
Ensure label lines avoid overlapping text

### DIFF
--- a/bit_field/render.py
+++ b/bit_field/render.py
@@ -212,7 +212,7 @@ class Renderer(object):
             raise ValueError('label_lines start_line and end_line must be non-negative')
         if end >= self.lanes or start >= self.lanes:
             raise ValueError('label_lines start_line/end_line exceed number of lanes')
-        if end - start < 1:
+        if end - start < 2:
             raise ValueError('label_lines must cover at least 2 lines')
         layout = self.label_lines['layout']
         if layout not in ('left', 'right'):
@@ -247,7 +247,8 @@ class Renderer(object):
 
         half_cage = (right-left)/2
         lines = text.split('\n')
-        text_length = width+(self.cage_width*(end-start)/2)
+        max_text_len = max((len(line) for line in lines), default=0)
+        text_length = max_text_len * font_size * 0.6
         text_attrs = {
             'x': x,
             'y': mid_y,
@@ -256,15 +257,12 @@ class Renderer(object):
             'font-weight': self.fontweight,
             'text-anchor': 'middle',
             'dominant-baseline': 'middle',
-            'transform': 'rotate({},{},{})'.format(angle, x, mid_y),
-            'textLength': text_length,
-            'lengthAdjust': 'spacingAndGlyphs'
+            'transform': 'rotate({},{},{})'.format(angle, x, mid_y)
         }
         if len(lines) == 1:
+            text_attrs['textLength'] = text_length
+            text_attrs['lengthAdjust'] = 'spacingAndGlyphs'
             text_element = ['text', text_attrs, text]
-            y_height = text_length
-            top_y2 = mid_y-y_height/2-5
-            bottom_y1 = mid_y+y_height/2+5
         else:
             line_height = font_size * 1.2
             start_y = mid_y - line_height * (len(lines) - 1) / 2
@@ -274,12 +272,9 @@ class Renderer(object):
             elements = ['text', attrs]
             for i, line in enumerate(lines):
                 elements.append(['tspan', {'x': x, 'y': start_y + line_height * i}, line])
-                y_height = start_y + line_height * i
-            
-            top_y2 = start_y - 5
-            bottom_y1 = y_height+5
-            
             text_element = elements
+        top_y2 = mid_y - text_length / 2 - 5
+        bottom_y1 = mid_y + text_length / 2 + 5
 
         bracket = ['g', {
             'stroke': 'black',

--- a/bit_field/test/test_label_lines.py
+++ b/bit_field/test/test_label_lines.py
@@ -46,14 +46,19 @@ def test_label_lines_draws_text_outside_right():
     assert attrs["font-size"] == 6
     assert "rotate(90" in attrs.get("transform", "")
     assert attrs["x"] == pytest.approx(720)
-    assert attrs["textLength"] == pytest.approx(80)
+    expected_len = len("Demo") * 6 * 0.6
+    assert attrs["textLength"] == pytest.approx(expected_len)
     top_y = 14 * 1.2
     vlane = 80 - 14 * 1.2
     bottom_y = top_y + vlane * 4
+    mid_y = (top_y + bottom_y) / 2
+    top_gap_end = mid_y - expected_len / 2 - 5
+    bottom_gap_start = mid_y + expected_len / 2 + 5
     assert _find_line(res, 680, 760, top_y, top_y) is not None
     assert _find_line(res, 680, 760, bottom_y, bottom_y) is not None
-    assert _find_line(res, 680, 680, top_y, bottom_y) is not None
-    assert _find_line(res, 760, 760, top_y, bottom_y) is not None
+    assert _find_line(res, 720, 720, top_y, top_gap_end) is not None
+    assert _find_line(res, 720, 720, bottom_gap_start, bottom_y) is not None
+    assert _find_line(res, 720, 720, top_gap_end, bottom_gap_start) is None
 
 
 def test_label_lines_draws_text_outside_left():
@@ -69,13 +74,18 @@ def test_label_lines_draws_text_outside_left():
     root_attrs = root[1]
     view_min_x = float(root_attrs["viewBox"].split()[0])
     assert view_min_x == pytest.approx(-120)
+    expected_len = len("Demo") * 6 * 0.6
     top_y = 14 * 1.2
     vlane = 80 - 14 * 1.2
     bottom_y = top_y + vlane * 4
+    mid_y = (top_y + bottom_y) / 2
+    top_gap_end = mid_y - expected_len / 2 - 5
+    bottom_gap_start = mid_y + expected_len / 2 + 5
     assert _find_line(res, -120, -40, top_y, top_y) is not None
     assert _find_line(res, -120, -40, bottom_y, bottom_y) is not None
-    assert _find_line(res, -120, -120, top_y, bottom_y) is not None
-    assert _find_line(res, -40, -40, top_y, bottom_y) is not None
+    assert _find_line(res, -80, -80, top_y, top_gap_end) is not None
+    assert _find_line(res, -80, -80, bottom_gap_start, bottom_y) is not None
+    assert _find_line(res, -80, -80, top_gap_end, bottom_gap_start) is None
 
 
 def test_label_lines_multiline():
@@ -86,6 +96,16 @@ def test_label_lines_multiline():
     node2 = _find_text(res, "Line2")
     assert node1 is not None
     assert node2 is not None
+    expected_len = len("Line1") * 6 * 0.6
+    top_y = 14 * 1.2
+    vlane = 80 - 14 * 1.2
+    bottom_y = top_y + vlane * 4
+    mid_y = (top_y + bottom_y) / 2
+    top_gap_end = mid_y - expected_len / 2 - 5
+    bottom_gap_start = mid_y + expected_len / 2 + 5
+    assert _find_line(res, 720, 720, top_y, top_gap_end) is not None
+    assert _find_line(res, 720, 720, bottom_gap_start, bottom_y) is not None
+    assert _find_line(res, 720, 720, top_gap_end, bottom_gap_start) is None
 
 
 def test_label_lines_invalid_range():


### PR DESCRIPTION
## Summary
- compute label line text length dynamically and stop connecting lines 5px away from text
- require label line ranges to cover at least two lanes
- update tests for new label line behaviour

## Testing
- `pytest bit_field/test/test_label_lines.py -vv`
- `pytest` *(fails: subprocess.CalledProcessError: Command '['git', 'describe', '--tags', '--match', 'v*']`)*

------
https://chatgpt.com/codex/tasks/task_e_68beaea4e94c8320a3829294ca4b0b5a