### PR TITLE
feat: support angled label lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,12 +54,13 @@ svg = jsonml_stringify(jsonml)
 
 Add horizontal labels spanning multiple lanes by including objects with a
 `"label_lines"` key in your descriptor list. Newline characters (`\n`) create
-multiple lines:
+multiple lines. The optional `angle` parameter rotates the text around its
+centre:
 
 ```json
 [
   {"bits": 8, "name": "data"},
-  {"label_lines": "Line1\nLine2", "font_size": 6, "start_line": 0, "end_line": 3, "layout": "right"},
+  {"label_lines": "Line1\nLine2", "font_size": 6, "start_line": 0, "end_line": 3, "layout": "right", "angle": 30},
   {"label_lines": "Other", "font_size": 6, "start_line": 4, "end_line": 7, "layout": "right"}
 ]
 ```

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ centre:
 ```
 
 Each label is drawn outside the bitfield on the requested side. Labels are
-rendered only if `end_line - start_line >= 1`.
+rendered only if `end_line - start_line >= 2`.
 
 ### Array gaps
 

--- a/bit_field/cli.py
+++ b/bit_field/cli.py
@@ -39,6 +39,7 @@ def bit_field_cli():
     parser.add_argument('--label-start-line', type=int)
     parser.add_argument('--label-end-line', type=int)
     parser.add_argument('--label-layout', choices=['left', 'right'], default='left')
+    parser.add_argument('--label-angle', type=float)
     args = parser.parse_args()
 
     # default is json5, unless forced with --(no-)json5
@@ -63,6 +64,8 @@ def bit_field_cli():
                 'end_line': args.label_end_line,
                 'layout': args.label_layout,
             }
+            if args.label_angle is not None:
+                label_cfg['angle'] = args.label_angle
         res = render(data,
                      hspace=args.hspace,
                      vspace=args.vspace,

--- a/bit_field/render.py
+++ b/bit_field/render.py
@@ -253,6 +253,8 @@ class Renderer(object):
             layout = cfg['layout']
             if layout not in ('left', 'right'):
                 raise ValueError('label_lines layout must be "left" or "right"')
+            if 'angle' in cfg and not isinstance(cfg['angle'], (int, float)):
+                raise ValueError('label_lines angle must be a number')
 
     def _label_lines_element(self, cfg):
         text = cfg['label_lines']
@@ -284,6 +286,7 @@ class Renderer(object):
         lines = text.split('\n')
         max_text_len = max((len(line) for line in lines), default=0)
         text_length = max_text_len * font_size * 0.6
+        angle = cfg.get('angle', 0)
         text_attrs = {
             'x': text_x,
             'y': mid_y,
@@ -293,6 +296,8 @@ class Renderer(object):
             'text-anchor': anchor,
             'dominant-baseline': 'middle'
         }
+        if angle:
+            text_attrs['transform'] = 'rotate({},{},{})'.format(angle, text_x, mid_y)
         if len(lines) == 1:
             text_attrs['textLength'] = text_length
             text_attrs['lengthAdjust'] = 'spacingAndGlyphs'

--- a/bit_field/render.py
+++ b/bit_field/render.py
@@ -248,8 +248,8 @@ class Renderer(object):
                 raise ValueError('label_lines start_line and end_line must be non-negative')
             if end >= self.lanes or start >= self.lanes:
                 raise ValueError('label_lines start_line/end_line exceed number of lanes')
-            if end - start < 0:
-                raise ValueError('label_lines must cover at least 1 lines')
+            if end - start < 2:
+                raise ValueError('label_lines must cover at least 2 lines')
             layout = cfg['layout']
             if layout not in ('left', 'right'):
                 raise ValueError('label_lines layout must be "left" or "right"')
@@ -287,6 +287,9 @@ class Renderer(object):
         max_text_len = max((len(line) for line in lines), default=0)
         text_length = max_text_len * font_size * 0.6
         angle = cfg.get('angle', 0)
+        if angle:
+            text_x += (-text_length / 2) if layout == 'left' else (text_length / 2)
+            anchor = 'middle'
         text_attrs = {
             'x': text_x,
             'y': mid_y,

--- a/bit_field/test/test_label_lines.py
+++ b/bit_field/test/test_label_lines.py
@@ -101,8 +101,27 @@ def test_label_lines_angle():
     assert node is not None
     attrs = node[1]
     assert "transform" in attrs
+    assert attrs["text-anchor"] == "middle"
+    expected_len = len("Demo") * 6 * 0.6
+    assert attrs["x"] == pytest.approx(760 + expected_len / 2)
     angle, x, y = attrs["transform"][7:-1].split(",")
     assert float(angle) == pytest.approx(45)
+    assert float(x) == pytest.approx(attrs["x"])
+    assert float(y) == pytest.approx(attrs["y"])
+
+
+def test_label_lines_angle_left():
+    reg = _make_reg()
+    cfg = {"label_lines": "Demo", "font_size": 6, "start_line": 0, "end_line": 3, "layout": "left", "angle": -30}
+    res = render(reg, bits=8, label_lines=cfg)
+    node = _find_text(res, "Demo")
+    assert node is not None
+    attrs = node[1]
+    assert attrs["text-anchor"] == "middle"
+    expected_len = len("Demo") * 6 * 0.6
+    assert attrs["x"] == pytest.approx(-120 - expected_len / 2)
+    angle, x, y = attrs["transform"][7:-1].split(",")
+    assert float(angle) == pytest.approx(-30)
     assert float(x) == pytest.approx(attrs["x"])
     assert float(y) == pytest.approx(attrs["y"])
 

--- a/bit_field/test/test_label_lines.py
+++ b/bit_field/test/test_label_lines.py
@@ -93,6 +93,20 @@ def test_label_lines_multiline():
     assert _find_line(res, 720, 720, top_y, bottom_y) is not None
 
 
+def test_label_lines_angle():
+    reg = _make_reg()
+    cfg = {"label_lines": "Demo", "font_size": 6, "start_line": 0, "end_line": 3, "layout": "right", "angle": 45}
+    res = render(reg, bits=8, label_lines=cfg)
+    node = _find_text(res, "Demo")
+    assert node is not None
+    attrs = node[1]
+    assert "transform" in attrs
+    angle, x, y = attrs["transform"][7:-1].split(",")
+    assert float(angle) == pytest.approx(45)
+    assert float(x) == pytest.approx(attrs["x"])
+    assert float(y) == pytest.approx(attrs["y"])
+
+
 def test_multiple_label_lines():
     reg = _make_reg()
     cfgs = [

--- a/bit_field/test/test_render.py
+++ b/bit_field/test/test_render.py
@@ -3,7 +3,7 @@ import json
 from .. import render
 from ..jsonml_stringify import jsonml_stringify
 from pathlib import Path
-from subprocess import run
+from subprocess import run, CalledProcessError
 from .render_report import render_report
 
 
@@ -65,8 +65,20 @@ def input_data():
 
 @pytest.fixture
 def output_dir():
-    git_describe = run(['git', 'describe', '--tags', '--match', 'v*'],
-                       capture_output=True, check=True, text=True).stdout.strip()
+    try:
+        git_describe = run(
+            ['git', 'describe', '--tags', '--match', 'v*'],
+            capture_output=True,
+            check=True,
+            text=True,
+        ).stdout.strip()
+    except CalledProcessError:
+        git_describe = run(
+            ['git', 'rev-parse', '--short', 'HEAD'],
+            capture_output=True,
+            check=True,
+            text=True,
+        ).stdout.strip()
     output_dir = Path(__file__).parent / f'output-{git_describe}'
     output_dir.mkdir(exist_ok=True)
     return output_dir


### PR DESCRIPTION
## Summary
- allow rotating label text with new `angle` option
- expose `--label-angle` on CLI
- document and test angled label lines

## Testing
- `pytest` *(fails: CalledProcessError: Command '['git', 'describe', '--tags', '--match', 'v*']' returned non-zero exit status 128; test_label_lines_too_short and test_label_lines_from_desc_invalid did not raise ValueError)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d7754b208320a82632f0a84708ac