### PR TITLE
Add customizable gap width for array gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,12 +71,13 @@ rendered only if `end_line - start_line >= 1`.
 
 Use an `{"array": length}` descriptor to draw a wedge representing an
 unknown-length field or gap. The optional `type` and `name` keys colour and
-label the gap:
+label the gap, and `gap_width` adjusts the wedge width as a fraction of a
+single bit (default `0.5`):
 
 ```python
 reg = [
   {"name": "start", "bits": 8},
-  {"array": 8, "type": 4, "name": "gap"},
+  {"array": 8, "type": 4, "name": "gap", "gap_width": 0.75},
   {"name": "end", "bits": 8},
 ]
 render(reg, bits=16)

--- a/bit_field/render.py
+++ b/bit_field/render.py
@@ -368,7 +368,7 @@ class Renderer(object):
                 end_lane = (end - 1) // self.mod if end > 0 else 0
                 x1_raw = (start % self.mod) * step
                 x2_raw = (end % self.mod) * step
-                width = step / 2
+                width = step * e.get('gap_width', 0.5)
                 margin = step * 0.1
                 top_y = base_y + self.vlane * start_lane
                 bottom_y = base_y + self.vlane * (end_lane + 1)

--- a/bit_field/test/test_array_render.py
+++ b/bit_field/test/test_array_render.py
@@ -56,6 +56,31 @@ def test_array_polygon_type():
     assert c_x2 == pytest.approx(renderer.hspace)
 
 
+def test_array_gap_width():
+    reg = [
+        {'name': 'length1', 'bits': 8},
+        {'array': 8, 'gap_width': 1.0, 'name': 'gap'},
+        {'name': 'rest', 'bits': 8},
+    ]
+    renderer = Renderer(bits=16)
+    jsonml = renderer.render(reg)
+
+    def collect_polygons(node, polys):
+        if isinstance(node, list):
+            if node and node[0] == 'polygon':
+                polys.append(node[1])
+            for child in node[1:]:
+                collect_polygons(child, polys)
+
+    polygons = []
+    collect_polygons(jsonml, polygons)
+    white_poly = next(p for p in polygons if p.get('fill') == '#fff')
+    coords = [tuple(map(float, p.split(','))) for p in white_poly['points'].split()]
+    step = renderer.hspace / renderer.mod
+    width = step * 1.0
+    assert coords[1][0] == pytest.approx(coords[0][0] + width)
+    assert coords[3][0] == pytest.approx(coords[2][0] - width)
+
 def test_array_full_lane_wedge():
     reg = [
         {'name': 'head', 'bits': 8},


### PR DESCRIPTION
## Summary
- allow array gap descriptors to set `gap_width` controlling wedge width
- cover `gap_width` with unit tests
- document `gap_width` usage in README

## Testing
- `pytest bit_field/test/test_array_render.py -q`
- `pytest -q` *(fails: label line tests expect ValueError)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d71ab0a083208381b908270e83d9