### PR TITLE
Allow customizing array text color

### DIFF
--- a/bit_field/render.py
+++ b/bit_field/render.py
@@ -399,13 +399,16 @@ class Renderer(object):
                 if 'name' in e:
                     mid_x = (x1 + x2_outer) / 2
                     mid_y = (top_y + bottom_y) / 2 + self.fontsize / 2
+                    text_color = e.get('font_color', 'black')
                     grp.append(['text', {
                         'x': mid_x,
                         'y': mid_y,
                         'font-size': self.fontsize,
                         'font-family': self.fontfamily,
                         'font-weight': self.fontweight,
-                        'text-anchor': 'middle'
+                        'text-anchor': 'middle',
+                        'fill': text_color,
+                        'stroke': 'none'
                     }, e['name']])
                 res.append(grp)
                 bit_pos = end

--- a/bit_field/test/test_array_render.py
+++ b/bit_field/test/test_array_render.py
@@ -90,3 +90,51 @@ def test_array_full_lane_wedge():
     renderer = Renderer(bits=16)
     svg = jsonml_stringify(renderer.render(reg))
     assert f"{renderer.hspace}" in svg
+
+
+def test_array_text_default_black():
+    reg = [
+        {'name': 'length1', 'bits': 8},
+        {'array': 8, 'type': 4, 'name': 'gap'},
+        {'name': 'rest', 'bits': 8},
+    ]
+    renderer = Renderer(bits=16)
+    jsonml = renderer.render(reg)
+
+    def collect_texts(node, texts):
+        if isinstance(node, list):
+            if node and node[0] == 'text':
+                content = node[2] if len(node) > 2 else ''
+                texts.append((node[1], content))
+            for child in node[1:]:
+                collect_texts(child, texts)
+
+    texts = []
+    collect_texts(jsonml, texts)
+    gap_text = next(attrs for attrs, content in texts if content == 'gap')
+    assert gap_text.get('fill') == 'black'
+    assert gap_text.get('stroke') == 'none'
+
+
+def test_array_text_custom_color():
+    reg = [
+        {'name': 'length1', 'bits': 8},
+        {'array': 8, 'type': 4, 'name': 'gap', 'font_color': '#0f0'},
+        {'name': 'rest', 'bits': 8},
+    ]
+    renderer = Renderer(bits=16)
+    jsonml = renderer.render(reg)
+
+    def collect_texts(node, texts):
+        if isinstance(node, list):
+            if node and node[0] == 'text':
+                content = node[2] if len(node) > 2 else ''
+                texts.append((node[1], content))
+            for child in node[1:]:
+                collect_texts(child, texts)
+
+    texts = []
+    collect_texts(jsonml, texts)
+    gap_text = next(attrs for attrs, content in texts if content == 'gap')
+    assert gap_text.get('fill') == '#0f0'
+    assert gap_text.get('stroke') == 'none'


### PR DESCRIPTION
## Summary
- default array gap text to black
- add optional `font_color` to override text color for array gaps
- ensure tests cover default and custom text colors

## Testing
- `pytest bit_field/test/test_array_render.py::test_array_text_default_black bit_field/test/test_array_render.py::test_array_text_custom_color`
- `pytest` *(fails: Command '['git', 'describe', '--tags', '--match', 'v*']' returned non-zero exit status 128.)*

------
https://chatgpt.com/codex/tasks/task_e_68c1dbdb07ac832082c3f64f178d26ec