### PR TITLE
Allow customizing array gap fill color

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,12 +71,12 @@ rendered only if `end_line - start_line >= 1`.
 
 Use an `{"array": length}` descriptor to draw a wedge representing an
 unknown-length field or gap. The optional `type` and `name` keys colour and
-label the gap:
+label the gap. A `gap_fill` value customises the wedge colour (default `#fff`):
 
 ```python
 reg = [
   {"name": "start", "bits": 8},
-  {"array": 8, "type": 4, "name": "gap"},
+  {"array": 8, "type": 4, "name": "gap", "gap_fill": "#000"},  # black gap
   {"name": "end", "bits": 8},
 ]
 render(reg, bits=16)

--- a/bit_field/render.py
+++ b/bit_field/render.py
@@ -392,8 +392,9 @@ class Renderer(object):
                         'fill': typeColor(e['type']),
                         'stroke': 'none'
                     }])
-                # white gap polygon on top
-                grp.append(['polygon', {'points': pts, 'fill': '#fff'}])
+                # gap polygon on top, optionally with custom fill
+                gap_fill = e.get('gap_fill', e.get('fill', '#fff'))
+                grp.append(['polygon', {'points': pts, 'fill': gap_fill}])
                 grp.append(['line', {'x1': x1, 'y1': top_y, 'x2': x2, 'y2': bottom_y}])
                 grp.append(['line', {'x1': x1+width, 'y1': top_y, 'x2': x2_outer, 'y2': bottom_y}])
                 if 'name' in e:

--- a/bit_field/test/test_array_render.py
+++ b/bit_field/test/test_array_render.py
@@ -65,3 +65,25 @@ def test_array_full_lane_wedge():
     renderer = Renderer(bits=16)
     svg = jsonml_stringify(renderer.render(reg))
     assert f"{renderer.hspace}" in svg
+
+
+def test_array_custom_gap_fill():
+    reg = [
+        {'name': 'length1', 'bits': 8},
+        {'array': 8, 'type': 4, 'name': 'gap', 'gap_fill': '#000'},
+        {'name': 'rest', 'bits': 8},
+    ]
+    renderer = Renderer(bits=16)
+    jsonml = renderer.render(reg)
+
+    def collect_polygons(node, polys):
+        if isinstance(node, list):
+            if node and node[0] == 'polygon':
+                polys.append(node[1])
+            for child in node[1:]:
+                collect_polygons(child, polys)
+
+    polygons = []
+    collect_polygons(jsonml, polygons)
+    fills = [p.get('fill') for p in polygons]
+    assert '#000' in fills


### PR DESCRIPTION
## Summary
- allow `gap_fill` (or `fill`) on array descriptors to set wedge colour
- document array gap `gap_fill` option
- add regression test for custom gap fill

## Testing
- `pytest bit_field/test/test_array_render.py::test_array_polygon_type bit_field/test/test_array_render.py::test_array_custom_gap_fill -q`
- `pytest -q` *(fails: Command '['git', 'describe', '--tags', '--match', 'v*']' returned non-zero exit status 128)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e089e0f08320b2a3527ad8c5c07a