### PR TITLE
Adjust vertical label line spacing

### DIFF
--- a/bit_field/render.py
+++ b/bit_field/render.py
@@ -1,5 +1,6 @@
 from .tspan import tspan
 import colorsys
+import math
 
 
 def t(x, y):
@@ -131,7 +132,21 @@ class Renderer(object):
                 lines = cfg['label_lines'].split('\n')
                 max_text_len = max((len(line) for line in lines), default=0)
                 text_length = max_text_len * font_size * 0.6
-                margin = self.label_width / 2 + 2 * self.label_gap + text_length
+                angle = cfg.get('angle', 0) or 0
+                normalized = angle % 360
+                is_vertical = math.isclose(normalized % 180, 90, abs_tol=1e-6)
+                text_gap = 20 if is_vertical else self.label_gap
+                angle_rad = math.radians(angle)
+                horizontal_extent = (
+                    abs(text_length * math.cos(angle_rad))
+                    + font_size * abs(math.sin(angle_rad))
+                )
+                margin = (
+                    self.label_width / 2
+                    + self.label_gap
+                    + text_gap
+                    + horizontal_extent
+                )
                 cfg['_margin'] = margin
                 active = [a for a in active if a['end'] >= cfg['start_line']]
                 offset = 0
@@ -260,7 +275,7 @@ class Renderer(object):
                 raise ValueError('label_lines start_line and end_line must be non-negative')
             if end >= self.lanes or start >= self.lanes:
                 raise ValueError('label_lines start_line/end_line exceed number of lanes')
-            if end - start < 0:
+            if end - start < 2:
                 raise ValueError('label_lines must cover at least 2 lines')
             layout = cfg['layout']
             if layout not in ('left', 'right'):
@@ -289,22 +304,29 @@ class Renderer(object):
             x = -(gap + width / 2 + offset)
             left = x - width / 2
             right = x + width / 2
-            text_x = x - gap
             anchor = 'end'
         else:
             x = self.hspace + gap + width / 2 + offset
             left = x - width / 2
             right = x + width / 2
-            text_x = x + gap
             anchor = 'start'
 
         lines = text.split('\n')
         max_text_len = max((len(line) for line in lines), default=0)
         text_length = max_text_len * font_size * 0.6
-        angle = cfg.get('angle', 0)
+        angle = cfg.get('angle', 0) or 0
+        normalized = angle % 360
+        is_vertical = math.isclose(normalized % 180, 90, abs_tol=1e-6)
+        text_gap = 20 if is_vertical else gap
+        arrow_x = left + self.cage_width / 2
+        if layout == 'left':
+            text_x = arrow_x - text_gap
+        else:
+            text_x = arrow_x + text_gap
         if angle:
-            text_x += (-text_length / 2) if layout == 'left' else (text_length / 2)
             anchor = 'middle'
+            if not is_vertical:
+                text_x += (-text_length / 2) if layout == 'left' else (text_length / 2)
         reserved_offset = self.vlane * 0.2 if cfg.get('Reserved') else 0
         text_attrs = {
             'x': text_x,

--- a/bit_field/test/test_label_lines.py
+++ b/bit_field/test/test_label_lines.py
@@ -110,6 +110,21 @@ def test_label_lines_angle():
     assert float(y) == pytest.approx(attrs["y"])
 
 
+def test_label_lines_angle_vertical_spacing():
+    reg = _make_reg()
+    cfg = {"label_lines": "Demo", "font_size": 6, "start_line": 0, "end_line": 3, "layout": "right", "angle": -90}
+    res = render(reg, bits=8, label_lines=cfg)
+    node = _find_text(res, "Demo")
+    assert node is not None
+    attrs = node[1]
+    assert attrs["text-anchor"] == "middle"
+    assert attrs["x"] == pytest.approx(740)
+    angle, x, y = attrs["transform"][7:-1].split(",")
+    assert float(angle) == pytest.approx(-90)
+    assert float(x) == pytest.approx(attrs["x"])
+    assert float(y) == pytest.approx(attrs["y"])
+
+
 def test_label_lines_angle_left():
     reg = _make_reg()
     cfg = {"label_lines": "Demo", "font_size": 6, "start_line": 0, "end_line": 3, "layout": "left", "angle": -30}


### PR DESCRIPTION
## Summary
- keep rotated label line text 20px away from its arrow by basing placement on the bracket center
- account for rotation when computing label margins and tighten validation for short spans
- add a regression test covering the -90° label rotation spacing

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5448afc588320a2f88fdecf4dcb5b