### PR TITLE
Add padding for label line text

### DIFF
--- a/bit_field/render.py
+++ b/bit_field/render.py
@@ -294,6 +294,14 @@ class Renderer(object):
         if self.label_lines is not None:
             left_margin, right_margin = self._label_lines_margins()
 
+            has_left = any(cfg.get('layout') == 'left' for cfg in self.label_lines)
+            has_right = any(cfg.get('layout') == 'right' for cfg in self.label_lines)
+
+            if has_left:
+                left_margin += 5
+            if has_right:
+                right_margin += 5
+
         canvas_width = self.hspace + left_margin + right_margin
         view_min_x = -left_margin
 
@@ -354,7 +362,7 @@ class Renderer(object):
                 raise ValueError('label_lines start_line and end_line must be non-negative')
             if end >= self.lanes or start >= self.lanes:
                 raise ValueError('label_lines start_line/end_line exceed number of lanes')
-            if end - start < 0:
+            if end - start <= 1:
                 raise ValueError('label_lines must cover at least 2 lines')
             layout = cfg['layout']
             if layout not in ('left', 'right'):

--- a/bit_field/test/test_label_lines.py
+++ b/bit_field/test/test_label_lines.py
@@ -68,7 +68,7 @@ def test_label_lines_draws_text_outside_left():
     root = res
     root_attrs = root[1]
     view_min_x = float(root_attrs["viewBox"].split()[0])
-    assert view_min_x == pytest.approx(-134.4)
+    assert view_min_x == pytest.approx(-139.4)
     top_y = 14 * 1.2
     vlane = 80 - 14 * 1.2
     bottom_y = top_y + vlane * 4


### PR DESCRIPTION
## Summary
- add 5px of extra canvas padding on the sides where label_lines annotations appear to avoid clipping
- tighten label_lines length validation so the configured span must cover at least two lanes
- update the label line viewBox expectation to reflect the additional left padding

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d59e438e28832087669c928242acf9