### PR TITLE
Add arrow jump feature linking label lines and arrays

### DIFF
--- a/bit_field/render.py
+++ b/bit_field/render.py
@@ -102,6 +102,8 @@ def typeColor(t):
 
 
 class Renderer(object):
+    ARROW_JUMP_HEAD_LENGTH = 10
+
     def __init__(self,
                  vspace=80,
                  hspace=640,
@@ -382,6 +384,20 @@ class Renderer(object):
                           'd': 'M0,0 L10,3 L0,6 Z',
                           'fill': 'black'
                       }]
+                     ],
+                     ['marker', {
+                         'id': 'arrow-jump-head',
+                         'markerWidth': 10,
+                         'markerHeight': 6,
+                         'refX': 0,
+                         'refY': 3,
+                         'orient': 'auto',
+                         'markerUnits': 'strokeWidth'
+                     },
+                      ['path', {
+                          'd': 'M0,0 L10,3 L0,6 Z',
+                          'fill': 'black'
+                      }]
                      ]]
 
         res.append(arrow_def)
@@ -568,6 +584,9 @@ class Renderer(object):
     def _line_center_y(self, line, base_y):
         return base_y + self.vlane * line + self.vlane / 2
 
+    def _arrow_jump_head_extent(self, stroke_width):
+        return self.ARROW_JUMP_HEAD_LENGTH * stroke_width
+
     def _arrow_jump_elements(self):
         if not self.arrow_jumps:
             return None
@@ -593,12 +612,18 @@ class Renderer(object):
             first_y = self._line_center_y(cfg['jump_to_first'], base_y)
             second_y = self._line_center_y(cfg['jump_to_second'], base_y)
 
+            arrow_head_length = self._arrow_jump_head_extent(stroke_width)
+            if cfg['layout'] == 'left':
+                final_x = end_x - arrow_head_length
+            else:
+                final_x = end_x + arrow_head_length
+
             points = [
                 (start_x, start_y),
                 (start_x, first_y),
                 (outer_x, first_y),
                 (outer_x, second_y),
-                (end_x, second_y),
+                (final_x, second_y),
             ]
 
             commands = [f"M{points[0][0]},{points[0][1]}"]
@@ -608,7 +633,7 @@ class Renderer(object):
                 'stroke': 'black',
                 'stroke-width': stroke_width,
                 'fill': 'none',
-                'marker-end': 'url(#arrow)'
+                'marker-end': 'url(#arrow-jump-head)'
             }]
             group.append(path)
 

--- a/bit_field/render.py
+++ b/bit_field/render.py
@@ -268,7 +268,26 @@ class Renderer(object):
                         right_margin = max(right_margin, offset + margin)
                 else:
                     stroke_width = cfg.get('stroke_width', 3)
-                    outer_distance = min(10, cfg.get('outer_distance', 10))
+                    base_outer = cfg.get('outer_distance', 10)
+                    outer_distance = min(base_outer, 10)
+                    arrow_head_length = self._arrow_jump_head_extent(stroke_width)
+
+                    if cfg['layout'] == 'left':
+                        end_x = self._bit_column_x(cfg['end_bit'])
+                        final_x = end_x - arrow_head_length
+                        if final_x <= -outer_distance:
+                            max_outer = max(outer_distance, cfg.get('max_outer_distance', 25))
+                            required = arrow_head_length - end_x + stroke_width
+                            outer_distance = min(max_outer, max(outer_distance, required))
+                    else:
+                        end_x = self._bit_column_x(cfg['end_bit'])
+                        final_x = end_x + arrow_head_length
+                        limit = self.hspace + outer_distance
+                        if final_x >= limit:
+                            max_outer = max(outer_distance, cfg.get('max_outer_distance', 25))
+                            required = final_x - self.hspace + stroke_width
+                            outer_distance = min(max_outer, max(outer_distance, required))
+
                     margin = outer_distance + stroke_width / 2
                     cfg['_outer_distance'] = outer_distance
                     cfg['_margin'] = margin

--- a/bit_field/render.py
+++ b/bit_field/render.py
@@ -253,22 +253,28 @@ class Renderer(object):
                     )
                     cfg_start = cfg['start_line']
                     cfg_end = cfg['end_line']
-                else:
-                    margin = self.label_gap + self.label_width
                     cfg['_margin'] = margin
-                    cfg_start = min(cfg['start_line'], cfg['jump_to_first'], cfg['jump_to_second'])
-                    cfg_end = max(cfg['start_line'], cfg['jump_to_first'], cfg['jump_to_second'])
-                cfg['_margin'] = margin
-                active = [a for a in active if a['end'] >= cfg_start]
-                offset = 0
-                for a in active:
-                    offset = max(offset, a['offset'] + a['margin'])
-                cfg['_offset'] = offset
-                active.append({'end': cfg_end, 'offset': offset, 'margin': margin})
-                if side == 'left':
-                    left_margin = max(left_margin, offset + margin)
+                    active = [a for a in active if a['end'] >= cfg_start]
+                    offset = 0
+                    for a in active:
+                        offset = max(offset, a['offset'] + a['margin'])
+                    cfg['_offset'] = offset
+                    active.append({'end': cfg_end, 'offset': offset, 'margin': margin})
+                    if side == 'left':
+                        left_margin = max(left_margin, offset + margin)
+                    else:
+                        right_margin = max(right_margin, offset + margin)
                 else:
-                    right_margin = max(right_margin, offset + margin)
+                    stroke_width = cfg.get('stroke_width', 3)
+                    outer_distance = min(10, cfg.get('outer_distance', 10))
+                    margin = outer_distance + stroke_width / 2
+                    cfg['_outer_distance'] = outer_distance
+                    cfg['_margin'] = margin
+                    cfg['_offset'] = 0
+                    if side == 'left':
+                        left_margin = max(left_margin, margin)
+                    else:
+                        right_margin = max(right_margin, margin)
 
         self.label_margin = max(left_margin, right_margin)
         return left_margin, right_margin
@@ -574,12 +580,11 @@ class Renderer(object):
 
         for cfg in self.arrow_jumps:
             stroke_width = cfg.get('stroke_width', 3)
-            margin = cfg.get('_margin', self.label_gap + self.label_width if self.label_gap else self.hspace / self.mod)
-            offset = cfg.get('_offset', 0)
+            outer_distance = cfg.get('_outer_distance', 10)
             if cfg['layout'] == 'left':
-                outer_x = -(offset + margin)
+                outer_x = -outer_distance
             else:
-                outer_x = self.hspace + offset + margin
+                outer_x = self.hspace + outer_distance
 
             start_x = self._bit_column_x(cfg['arrow_jump'])
             end_x = self._bit_column_x(cfg['end_bit'])

--- a/bit_field/test/test_label_lines.py
+++ b/bit_field/test/test_label_lines.py
@@ -255,7 +255,7 @@ def test_arrow_jump_draws_path_left():
     renderer = Renderer(bits=8, arrow_jumps=cfg)
     res = renderer.render(reg)
 
-    path_node = _find_path(res, lambda attrs: attrs.get("marker-end") == "url(#arrow)")
+    path_node = _find_path(res, lambda attrs: attrs.get("marker-end") == "url(#arrow-jump-head)")
     assert path_node is not None
     attrs = path_node[1]
     assert attrs["stroke-width"] == 3
@@ -269,12 +269,14 @@ def test_arrow_jump_draws_path_left():
     assert renderer.arrow_jumps[0]["_offset"] == 0
     outer_x = -outer_distance
 
+    arrow_head = renderer._arrow_jump_head_extent(float(attrs["stroke-width"]))
+
     expected_points = [
         (bit_x(cfg["arrow_jump"]), line_center(cfg["start_line"])),
         (bit_x(cfg["arrow_jump"]), line_center(cfg["jump_to_first"])),
         (outer_x, line_center(cfg["jump_to_first"])),
         (outer_x, line_center(cfg["jump_to_second"])),
-        (bit_x(cfg["end_bit"]), line_center(cfg["jump_to_second"])),
+        (bit_x(cfg["end_bit"]) - arrow_head, line_center(cfg["jump_to_second"])),
     ]
 
     commands = attrs["d"].split()
@@ -312,5 +314,5 @@ def test_arrow_jump_from_desc():
         "end_bit": 2,
     })
     res = render(reg, bits=8)
-    path_node = _find_path(res, lambda attrs: attrs.get("marker-end") == "url(#arrow)")
+    path_node = _find_path(res, lambda attrs: attrs.get("marker-end") == "url(#arrow-jump-head)")
     assert path_node is not None

--- a/bit_field/test/test_label_lines.py
+++ b/bit_field/test/test_label_lines.py
@@ -316,3 +316,32 @@ def test_arrow_jump_from_desc():
     res = render(reg, bits=8)
     path_node = _find_path(res, lambda attrs: attrs.get("marker-end") == "url(#arrow-jump-head)")
     assert path_node is not None
+
+
+def test_arrow_jump_leftmost_end_bit_extends_margin_for_direction():
+    reg = _make_reg(bits=32, lanes=6)
+    cfg = {
+        "arrow_jump": 5,
+        "start_line": 2,
+        "jump_to_first": 3,
+        "layout": "left",
+        "jump_to_second": 5,
+        "end_bit": 0,
+    }
+    renderer = Renderer(bits=32, arrow_jumps=cfg, vflip=True)
+    res = renderer.render(reg)
+
+    arrow_cfg = renderer.arrow_jumps[0]
+    assert arrow_cfg["_outer_distance"] == pytest.approx(23)
+
+    path_node = _find_path(res, lambda attrs: attrs.get("marker-end") == "url(#arrow-jump-head)")
+    assert path_node is not None
+    attrs = path_node[1]
+
+    commands = attrs["d"].split()
+    points = [tuple(map(float, commands[0][1:].split(",")))]
+    points.extend(tuple(map(float, cmd[1:].split(","))) for cmd in commands[1:])
+
+    outer_x = -arrow_cfg["_outer_distance"]
+    final_point = points[-1]
+    assert final_point[0] > outer_x

--- a/bit_field/test/test_label_lines.py
+++ b/bit_field/test/test_label_lines.py
@@ -264,9 +264,10 @@ def test_arrow_jump_draws_path_left():
     base_y = renderer.fontsize * 1.2
     line_center = lambda line: base_y + renderer.vlane * line + renderer.vlane / 2
     bit_x = lambda bit: step * (renderer.mod - bit - 0.5)
-    offset = renderer.arrow_jumps[0]["_offset"]
-    margin = renderer.arrow_jumps[0]["_margin"]
-    outer_x = -(offset + margin)
+    outer_distance = renderer.arrow_jumps[0]["_outer_distance"]
+    assert outer_distance == pytest.approx(10)
+    assert renderer.arrow_jumps[0]["_offset"] == 0
+    outer_x = -outer_distance
 
     expected_points = [
         (bit_x(cfg["arrow_jump"]), line_center(cfg["start_line"])),
@@ -297,7 +298,7 @@ def test_arrow_jump_updates_viewbox_left_margin():
     }
     res = render(reg, bits=8, arrow_jumps=cfg)
     view_min_x = float(res[1]["viewBox"].split()[0])
-    assert view_min_x < 0
+    assert view_min_x == pytest.approx(-16.5)
 
 
 def test_arrow_jump_from_desc():


### PR DESCRIPTION
## Summary
- add an `arrow_jumps` feature that renders routed arrows alongside label lines and arrays
- update margin calculations so label line and arrow jump layouts can coexist without overlapping
- cover the new behaviour with renderer tests for drawing, margins, and descriptor extraction

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5b5981c688320a467be699a30007d