### PR TITLE
Ensure array gap fill color covers background when no type provided

### DIFF
--- a/bit_field/render.py
+++ b/bit_field/render.py
@@ -712,15 +712,23 @@ class Renderer(object):
                 pts = f"{x1},{top_y} {x1+width},{top_y} {x2_outer},{bottom_y} {x2},{bottom_y}"
                 color = self.type_color(e.get('type')) if e.get('type') is not None else 'black'
                 grp = ['g', {'stroke': color, 'stroke-width': self.stroke_width}]
-                # fill the full gap bounds with the type color to avoid transparent edges
+                # fill the full gap bounds to avoid transparent edges
+                background_fill = None
                 if e.get('type') is not None:
+                    background_fill = self.type_color(e['type'])
+                else:
+                    if e.get('fill') is not None:
+                        background_fill = e.get('fill')
+                    elif e.get('gap_fill') is not None:
+                        background_fill = e.get('gap_fill')
+                if background_fill is not None:
                     # use raw coordinates so the background reaches the lane boundaries
                     left = x1_raw
                     right = self.hspace if (x2_raw == 0 and end > start) else x2_raw
                     rect = f"{left},{top_y} {right},{top_y} {right},{bottom_y} {left},{bottom_y}"
                     grp.append(['polygon', {
                         'points': rect,
-                        'fill': self.type_color(e['type']),
+                        'fill': background_fill,
                         'stroke': 'none'
                     }])
                 # gap polygon on top, optionally with custom fill

--- a/bit_field/render.py
+++ b/bit_field/render.py
@@ -759,6 +759,42 @@ class Renderer(object):
                 else:
                     polygon_attrs['stroke'] = 'none'
                 grp.append(['polygon', polygon_attrs])
+                if not show_lines:
+                    trailing_offset = end % self.mod
+                    if trailing_offset:
+                        lane_idx = end_lane
+                        skip_count = 0
+                        if self.uneven and self.lanes > 1 and lane_idx == self.lanes - 1:
+                            skip_count = self.mod - self.total_bits % self.mod
+                            if skip_count == self.mod:
+                                skip_count = 0
+                        lane_start_bit = lane_idx * self.mod
+                        lane_width_bits = self.mod - skip_count
+                        boundary_segments = self._boundary_segments(
+                            lane_start_bit,
+                            lane_width_bits,
+                            lane_start_bit,
+                        )
+                        if boundary_segments:
+                            hpos = 0 if self.vflip else step * skip_count
+                            lane_top = base_y + self.vlane * lane_idx
+                            for seg_start, seg_end in boundary_segments:
+                                if seg_end <= trailing_offset:
+                                    continue
+                                seg_start = max(seg_start, trailing_offset)
+                                if seg_start >= seg_end:
+                                    continue
+                                x_start = hpos + seg_start * step
+                                x_end = hpos + seg_end * step
+                                grp.append(['line', {
+                                    'x1': x_start,
+                                    'y1': lane_top,
+                                    'x2': x_end,
+                                    'y2': lane_top,
+                                    'stroke': 'black',
+                                    'stroke-width': self.stroke_width,
+                                    'stroke-linecap': 'butt',
+                                }])
                 if show_lines:
                     grp.append(['line', {
                         'x1': x1,

--- a/bit_field/render.py
+++ b/bit_field/render.py
@@ -723,14 +723,22 @@ class Renderer(object):
                         background_fill = e.get('gap_fill')
                 if background_fill is not None:
                     # use raw coordinates so the background reaches the lane boundaries
-                    left = x1_raw
-                    right = self.hspace if (x2_raw == 0 and end > start) else x2_raw
-                    rect = f"{left},{top_y} {right},{top_y} {right},{bottom_y} {left},{bottom_y}"
-                    grp.append(['polygon', {
-                        'points': rect,
-                        'fill': background_fill,
-                        'stroke': 'none'
-                    }])
+                    for lane_idx in range(start_lane, end_lane + 1):
+                        lane_top = base_y + self.vlane * lane_idx
+                        lane_bottom = base_y + self.vlane * (lane_idx + 1)
+                        left = x1_raw if lane_idx == start_lane else 0
+                        if lane_idx == end_lane:
+                            right = x2_raw
+                            if right == 0 and end > start:
+                                right = self.hspace
+                        else:
+                            right = self.hspace
+                        rect = f"{left},{lane_top} {right},{lane_top} {right},{lane_bottom} {left},{lane_bottom}"
+                        grp.append(['polygon', {
+                            'points': rect,
+                            'fill': background_fill,
+                            'stroke': 'none'
+                        }])
                 # gap polygon on top, optionally with custom fill
                 gap_fill = e.get('gap_fill', e.get('fill', '#fff'))
                 grp.append(['polygon', {'points': pts, 'fill': gap_fill}])

--- a/bit_field/render.py
+++ b/bit_field/render.py
@@ -751,10 +751,20 @@ class Renderer(object):
                     center_y = (top_y + bottom_y) / 2
                     first_lane_center = top_y + self.vlane / 2
                     align_first_lane = (length % self.mod) != 0
+                    label_x = mid_x
+                    if align_first_lane:
+                        start_offset = start % self.mod
+                        if start_offset:
+                            first_lane_bits = min(length, self.mod - start_offset)
+                        else:
+                            first_lane_bits = min(length, self.mod)
+                        lane_left = x1_raw
+                        lane_right = lane_left + first_lane_bits * step
+                        label_x = (lane_left + lane_right) / 2
                     base_center = first_lane_center if align_first_lane else center_y
                     text_color = e.get('font_color', 'black')
                     text_attrs = {
-                        'x': mid_x,
+                        'x': label_x,
                         'font-size': self.fontsize,
                         'font-family': self.fontfamily,
                         'font-weight': self.fontweight,
@@ -779,7 +789,7 @@ class Renderer(object):
                             for j, span in enumerate(spans):
                                 span_attrs = dict(span[1])
                                 if j == 0:
-                                    span_attrs['x'] = mid_x
+                                    span_attrs['x'] = label_x
                                     span_attrs['y'] = first_line_y + line_height * i
                                 text_element.append(['tspan', span_attrs, span[2]])
                         grp.append(text_element)

--- a/bit_field/render.py
+++ b/bit_field/render.py
@@ -711,7 +711,11 @@ class Renderer(object):
                 x2 = x2_outer - width
                 pts = f"{x1},{top_y} {x1+width},{top_y} {x2_outer},{bottom_y} {x2},{bottom_y}"
                 color = self.type_color(e.get('type')) if e.get('type') is not None else 'black'
-                grp = ['g', {'stroke': color, 'stroke-width': self.stroke_width}]
+                show_lines = not e.get('hide_lines')
+                grp_attrs = {'stroke-width': self.stroke_width}
+                if show_lines:
+                    grp_attrs['stroke'] = color
+                grp = ['g', grp_attrs]
                 # fill the full gap bounds to avoid transparent edges
                 background_fill = None
                 if e.get('type') is not None:
@@ -741,9 +745,27 @@ class Renderer(object):
                         }])
                 # gap polygon on top, optionally with custom fill
                 gap_fill = e.get('gap_fill', e.get('fill', '#fff'))
-                grp.append(['polygon', {'points': pts, 'fill': gap_fill}])
-                grp.append(['line', {'x1': x1, 'y1': top_y, 'x2': x2, 'y2': bottom_y}])
-                grp.append(['line', {'x1': x1+width, 'y1': top_y, 'x2': x2_outer, 'y2': bottom_y}])
+                polygon_attrs = {'points': pts, 'fill': gap_fill}
+                if show_lines:
+                    polygon_attrs['stroke'] = color
+                else:
+                    polygon_attrs['stroke'] = 'none'
+                grp.append(['polygon', polygon_attrs])
+                if show_lines:
+                    grp.append(['line', {
+                        'x1': x1,
+                        'y1': top_y,
+                        'x2': x2,
+                        'y2': bottom_y,
+                        'stroke': color,
+                    }])
+                    grp.append(['line', {
+                        'x1': x1 + width,
+                        'y1': top_y,
+                        'x2': x2_outer,
+                        'y2': bottom_y,
+                        'stroke': color,
+                    }])
                 if 'name' in e:
                     name = str(e['name'])
                     lines = name.split('\n')

--- a/bit_field/render.py
+++ b/bit_field/render.py
@@ -1070,19 +1070,19 @@ class Renderer(object):
             res = ['g', {}, blanks, names, attrs]
         return res
 
-    def hline(self, len, x=0, y=0, padding=0):
+    def hline(self, length, x=0, y=0, padding=0):
         res = ['line']
-        att = {}
         if padding != 0:
-            len -= padding
-            x += padding/2
-        if x != 0:
-            att['x1'] = x
-        if len != 0:
-            att['x2'] = x + len
-        if y != 0:
-            att['y1'] = y
-            att['y2'] = y
+            length -= padding
+            x += padding / 2
+
+        end_x = x + length
+        att = {
+            'x1': x,
+            'x2': end_x,
+            'y1': y,
+            'y2': y,
+        }
         res.append(att)
         return res
 

--- a/bit_field/render.py
+++ b/bit_field/render.py
@@ -749,6 +749,9 @@ class Renderer(object):
                     lines = name.split('\n')
                     mid_x = (x1 + x2_outer) / 2
                     center_y = (top_y + bottom_y) / 2
+                    first_lane_center = top_y + self.vlane / 2
+                    align_first_lane = (length % self.mod) != 0
+                    base_center = first_lane_center if align_first_lane else center_y
                     text_color = e.get('font_color', 'black')
                     text_attrs = {
                         'x': mid_x,
@@ -760,11 +763,14 @@ class Renderer(object):
                         'stroke': 'none'
                     }
                     if len(lines) == 1:
-                        text_attrs['y'] = center_y + self.fontsize / 2
+                        text_attrs['y'] = base_center + self.fontsize / 2
                         grp.append(['text', text_attrs] + tspan(lines[0]))
                     else:
                         line_height = self.fontsize * 1.2
-                        first_line_y = center_y + self.fontsize / 2 - line_height * (len(lines) - 1) / 2
+                        if align_first_lane:
+                            first_line_y = first_lane_center + self.fontsize / 2
+                        else:
+                            first_line_y = center_y + self.fontsize / 2 - line_height * (len(lines) - 1) / 2
                         text_element = ['text', text_attrs]
                         for i, line in enumerate(lines):
                             spans = tspan(line)

--- a/bit_field/render.py
+++ b/bit_field/render.py
@@ -727,9 +727,17 @@ class Renderer(object):
                         background_fill = e.get('gap_fill')
                 if background_fill is not None:
                     # use raw coordinates so the background reaches the lane boundaries
+                    overlap = 0.0
+                    if end_lane > start_lane:
+                        overlap = min(self.vlane * 0.05, 0.5)
                     for lane_idx in range(start_lane, end_lane + 1):
                         lane_top = base_y + self.vlane * lane_idx
                         lane_bottom = base_y + self.vlane * (lane_idx + 1)
+                        if overlap:
+                            if lane_idx > start_lane:
+                                lane_top -= overlap
+                            if lane_idx < end_lane:
+                                lane_bottom += overlap
                         left = x1_raw if lane_idx == start_lane else 0
                         if lane_idx == end_lane:
                             right = x2_raw

--- a/bit_field/test/test_array_render.py
+++ b/bit_field/test/test_array_render.py
@@ -198,6 +198,17 @@ def test_array_text_aligns_to_first_lane_when_partial():
     expected_y = first_lane_center + renderer.fontsize / 2
     assert float(gap_text['y']) == pytest.approx(expected_y)
 
+    step = renderer.hspace / renderer.mod
+    start_offset = 96 % renderer.mod
+    if start_offset:
+        first_lane_bits = min(48, renderer.mod - start_offset)
+    else:
+        first_lane_bits = min(48, renderer.mod)
+    lane_left = start_offset * step
+    lane_right = lane_left + first_lane_bits * step
+    expected_x = (lane_left + lane_right) / 2
+    assert float(gap_text['x']) == pytest.approx(expected_x)
+
 
 def test_array_text_stays_centered_for_full_lane_multiples():
     reg = [

--- a/bit_field/test/test_array_render.py
+++ b/bit_field/test/test_array_render.py
@@ -215,6 +215,10 @@ def test_hidden_array_draws_boundary_for_following_fields():
 
     assert trailing_segments, 'expected a horizontal boundary after the hidden array'
 
+    segment = trailing_segments[0]
+    assert segment.get('y1') == pytest.approx(0)
+    assert segment.get('y2') == pytest.approx(0)
+
 
 def test_array_text_aligns_to_first_lane_when_partial():
     reg = [

--- a/bit_field/test/test_array_render.py
+++ b/bit_field/test/test_array_render.py
@@ -89,6 +89,33 @@ def test_array_gap_width():
     assert coords[1][0] == pytest.approx(coords[0][0] + width)
     assert coords[3][0] == pytest.approx(coords[2][0] - width)
 
+
+def test_array_gap_fill_used_for_background_when_no_type():
+    reg = [
+        {'name': 'length1', 'bits': 8},
+        {'array': 8, 'gap_fill': '#abc', 'name': 'gap'},
+        {'name': 'rest', 'bits': 8},
+    ]
+    renderer = Renderer(bits=16)
+    jsonml = renderer.render(reg)
+
+    def collect_polygons(node, polys):
+        if isinstance(node, list):
+            if node and node[0] == 'polygon':
+                polys.append(node[1])
+            for child in node[1:]:
+                collect_polygons(child, polys)
+
+    polygons = []
+    collect_polygons(jsonml, polygons)
+
+    background = [
+        p for p in polygons
+        if p.get('fill') == '#abc' and p.get('stroke') == 'none'
+    ]
+    assert background, 'expected background polygon to use gap_fill colour'
+
+
 def test_array_full_lane_wedge():
     reg = [
         {'name': 'head', 'bits': 8},

--- a/bit_field/test/test_array_render.py
+++ b/bit_field/test/test_array_render.py
@@ -354,6 +354,21 @@ def test_array_hide_lines_skips_grid_and_horizontal():
         if attrs.get('y1', 0) == attrs.get('y2', 0)
     ]
     tiny_verticals = [attrs for attrs in lines if attrs.get('y2') == 7.9]
+    styled_lines = [attrs for attrs in lines if 'stroke' in attrs]
 
     assert len(horizontals) == 2
     assert tiny_verticals == []
+    assert styled_lines == []
+
+    polygons = []
+
+    def collect_polygons(node):
+        if isinstance(node, list):
+            if node and node[0] == 'polygon':
+                polygons.append(node[1])
+            for child in node[1:]:
+                collect_polygons(child)
+
+    collect_polygons(jsonml)
+
+    assert all(poly.get('stroke') in (None, 'none') for poly in polygons)


### PR DESCRIPTION
## Summary
- ensure array gaps use type, fill, or gap_fill colours to paint the background so no transparent area remains
- add a regression test covering gap_fill background rendering without an explicit type

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d6dc18d748832081ab7b48bfc72df3