### PR TITLE
Add config flag to toggle bit number labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,20 @@ field types and to use human-readable labels in your payload:
   ]
 }
 ```
+
+Disable the bit number labels drawn above each field by setting
+`"number_draw": false` in your configuration:
+
+```json
+{
+  "config": {
+    "number_draw": false
+  },
+  "payload": [
+    { "name": "Lorem ipsum dolor", "bits": 32 }
+  ]
+}
+```
 ![Json Example](example/example.svg)
 
 Rendering with the CLI:

--- a/bit_field/render.py
+++ b/bit_field/render.py
@@ -171,6 +171,7 @@ class Renderer(object):
 
         self.grid_draw = grid_draw
         self.number_draw = number_draw
+        self.bit_label_height = self.fontsize * 1.2 if self.number_draw else 0
         self.type_overrides = _parse_type_overrides(types)
 
     def get_total_bits(self, desc):
@@ -345,10 +346,10 @@ class Renderer(object):
                     max_attr_count = max(max_attr_count, 1)
 
         if not self.compact:
-            self.vlane = self.vspace - self.fontsize * (1.2 + max_attr_count)
+            self.vlane = self.vspace - (self.bit_label_height + self.fontsize * max_attr_count)
             height = self.vspace * self.lanes  + self.stroke_width / 2
         else:
-            self.vlane = self.vspace - self.fontsize * 1.2
+            self.vlane = self.vspace - self.bit_label_height
             height = self.vlane * (self.lanes - 1) + self.vspace + self.stroke_width / 2
         if self.legend:
             height += self.fontsize * 1.2
@@ -511,7 +512,7 @@ class Renderer(object):
         start = cfg['start_line']
         end = cfg['end_line']
         layout = cfg['layout']
-        base_y = self.fontsize * 1.2
+        base_y = self.bit_label_height
         if self.legend:
             base_y += self.fontsize * 1.2
         top_y = base_y + self.vlane * start
@@ -612,7 +613,7 @@ class Renderer(object):
         if not self.arrow_jumps:
             return None
 
-        base_y = self.fontsize * 1.2
+        base_y = self.bit_label_height
         if self.legend:
             base_y += self.fontsize * 1.2
 
@@ -686,7 +687,7 @@ class Renderer(object):
 
     def array_gaps(self, desc):
         step = self.hspace / self.mod
-        base_y = self.fontsize * 1.2
+        base_y = self.bit_label_height
         res = ['g', {}]
         bit_pos = 0
         for e in desc:
@@ -786,7 +787,7 @@ class Renderer(object):
 
     def cage(self, desc):
         if not self.compact or self.index == 0:
-            dy = self.fontsize * 1.2
+            dy = self.bit_label_height
         else:
             dy = 0
         res = ['g', {
@@ -986,9 +987,10 @@ class Renderer(object):
                             'font-weight': self.fontweight,
                         }, str(i if self.vflip else self.mod - i - 1)])
                 lane_children.append(bits)
-            lane_children.append(['g', {
-                'transform': t(0, self.fontsize*1.2)
-            }, blanks, names, attrs])
+            content_attrs = {}
+            if self.bit_label_height:
+                content_attrs['transform'] = t(0, self.bit_label_height)
+            lane_children.append(['g', content_attrs, blanks, names, attrs])
             res = ['g', {}, *lane_children]
         else:
             res = ['g', {}, blanks, names, attrs]

--- a/bit_field/test/test_render.py
+++ b/bit_field/test/test_render.py
@@ -164,3 +164,41 @@ def test_field_name_supports_newlines():
     assert any(span[2] == 'Lorem ipsum' for span in matching_spans)
     dolor_span = next(span for span in matching_spans if span[2] == 'dolor')
     assert 'dy' in dolor_span[1]
+
+
+def _collect_text_values(node, collected):
+    if isinstance(node, list):
+        if node and node[0] == 'text':
+            for child in node[2:]:
+                if isinstance(child, str):
+                    collected.append(child)
+        for child in node[1:]:
+            _collect_text_values(child, collected)
+
+
+def test_number_draw_enabled_by_default():
+    reg = [
+        {"name": "field", "bits": 8},
+    ]
+
+    jsonml = render(reg, bits=8)
+
+    texts = []
+    _collect_text_values(jsonml, texts)
+
+    assert '0' in texts
+    assert '7' in texts
+
+
+def test_number_draw_can_be_disabled():
+    reg = [
+        {"name": "field", "bits": 8},
+    ]
+
+    jsonml = render(reg, bits=8, number_draw=False)
+
+    texts = []
+    _collect_text_values(jsonml, texts)
+
+    assert '0' not in texts
+    assert '7' not in texts


### PR DESCRIPTION
## Summary
- add a `number_draw` renderer option to enable or disable bit-number labels
- update the documentation and tests to cover the new configuration flag

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d6f6c5fb78832095f900c3fb9420a4